### PR TITLE
Add jscs to toolchain since jshint ignores indentation as of v2.5.0

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,28 @@
+{
+  "validateIndentation":2,
+  // JSHint: "indent": 2,
+  "disallowMixedSpacesAndTabs":true,
+  // JSHint: "smarttabs":false,
+  "maximumLineLength":80,
+  // JSHint: "maxlen": 80,
+  "disallowTrailingWhitespace": true,
+  // JSHint: "trailing": true,
+  "requireCurlyBraces": [],
+  // JSHint: "curly": false,
+  "requireSpacesInConditionalExpression": true,
+  "requireSpacesInNamedFunctionExpression": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "disallowSpacesInNamedFunctionExpression": {
+    "beforeOpeningRoundBrace": true
+  },
+  "requireSpacesInAnonymousFunctionExpression": {
+    "beforeOpeningCurlyBrace": true,
+    "beforeOpeningRoundBrace": true
+  },
+  "validateJSDoc": {
+    "checkParamNames": true,
+    "checkRedundantParams": true,
+    "requireParamTypes": true
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
-all: jshint coverage
+.PHONY: setup
+
+all: jshint jscs coverage
 
 setup:
 	npm install
 
 jshint: setup
 	jshint algorithms data_structures test util
+
+jscs: setup
+	jscs --reporter=inline algorithms data_structures test util
 
 test: setup
 	mocha -R spec --recursive test

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "coveralls": "^2.10.0",
     "istanbul": "^0.2.10",
     "jshint": "~2.4.4",
-    "jscs": "1.4.5",
+    "jscs": "^1.4.5",
     "mocha": "^1.20.0"
   },
   "repository": {


### PR DESCRIPTION
- I have made jscs part of the all target even though it produces many errors right now.
- Made setup a phony target, because it is.
- There are more verbose reporters for jscs, but this terse one might be sufficient.
