### PR TITLE
Huffman encoding/decoding

### DIFF
--- a/algorithms/string/huffman.js
+++ b/algorithms/string/huffman.js
@@ -1,0 +1,232 @@
+/**
+ * Copyright (C) 2014 Eugene Sharygin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+'use strict';
+
+
+var huffman = {};
+
+
+/**
+ * Maximum block size used by functions "compress", "decompress".
+ *
+ * @const
+ */
+var MAX_BLOCK_SIZE = (-1 >>> 0).toString(2).length;
+
+
+/**
+ * Compress 0-1 string to int32 array.
+ *
+ * @param {string} string
+ * @return {number[]}
+ */
+var compress = function (string) {
+  var blocks = [];
+  var currentBlock = 0, currentBlockSize = 0;
+
+  string.split('').forEach(function (char) {
+    if (char == '0' || char == '1') {
+      currentBlock = (currentBlock << 1) | char;
+    }
+    else {
+      throw new Error('String must be binary (only 0s and 1s allowed).');
+    }
+    currentBlockSize += 1;
+
+    if (currentBlockSize == MAX_BLOCK_SIZE) {
+      blocks.push(currentBlock);
+      currentBlock = currentBlockSize = 0;
+    }
+  });
+
+  // Append last block size to the end.
+  if (currentBlockSize) {
+    blocks.push(currentBlock, currentBlockSize);
+  }
+  else {
+    blocks.push(MAX_BLOCK_SIZE);
+  }
+
+  return blocks;
+};
+
+
+/**
+ * Decompress int32 array back to 0-1 string.
+ *
+ * @param {number[]} array
+ * @return {string}
+ */
+var decompress = function (array) {
+  if (!array.length) {
+    return '';
+  }
+  else if (array.length == 1) {
+    throw new Error('Compressed array must be either empty ' +
+                    'or at least 2 blocks big.');
+  }
+
+  var padding = new Array(MAX_BLOCK_SIZE + 1).join(0);
+
+  var string = array.slice(0, -2).map(function (block) {
+    return (padding + (block >>> 0).toString(2)).slice(-padding.length);
+  }).join('');
+
+  // Append the last block.
+  var lastBlockSize = array.slice(-1)[0];
+  var lastBlock = array.slice(-2)[0];
+  string += (padding + (lastBlock >>> 0).toString(2)).slice(-lastBlockSize);
+
+  return string;
+};
+
+
+/**
+ * Apply Huffman encoding to a string.
+ *
+ * @param {string} string
+ * @param {boolean} [compressed=false] - Whether compress the string to bits.
+ * @return {{encoding: Object.<string, string>, value: string|number[]}}
+ */
+huffman.encode = function (string, compressed) {
+  if (!string.length) {
+    return {
+      encoding: {},
+      value: (compressed ? [] : '')
+    };
+  }
+
+  var counter = {};
+  string.split('').forEach(function (char) {
+    counter[char] = (counter[char] || 0) + 1;
+  });
+
+  var letters = Object.keys(counter).map(function (char) {
+    return {
+      char: char,
+      count: counter[char]
+    };
+  });
+
+  var compare = function (a, b) {
+    return a.count - b.count;
+  };
+  var less = function (a, b) {
+    return a && (b && (a.count < b.count) || !b);
+  };
+
+  letters.sort(compare);
+
+  // Each time two least letters are merged into one, the result is pushing into
+  // this buffer. Since the letters are pushing in ascending order of frequency,
+  // no more sorting is ever required.
+  var buffer = [];
+  var lettersIndex = 0, bufferIndex = 0;
+
+  var extractMinimum = function () {
+    return less(letters[lettersIndex], buffer[bufferIndex]) ?
+      letters[lettersIndex++] : buffer[bufferIndex++];
+  };
+
+  for (var numLetters = letters.length; numLetters > 1; --numLetters) {
+    var a = extractMinimum(), b = extractMinimum();
+    a.code = '0';
+    b.code = '1';
+    var union = {
+      count: a.count + b.count,
+      parts: [a, b]
+    };
+    buffer.push(union);
+  }
+
+  // At this point there is a single letter left.
+  var root = extractMinimum();
+  root.code = (letters.length > 1) ? '' : '0';
+
+  // Unroll the code recursively in reverse.
+  (function unroll(parent) {
+    if (parent.parts) {
+      var a = parent.parts[0], b = parent.parts[1];
+      a.code += parent.code;
+      b.code += parent.code;
+      unroll(a);
+      unroll(b);
+    }
+  }(root));
+
+  var encoding = letters.reduce(function (acc, letter) {
+    acc[letter.char] = letter.code.split('').reverse().join('');
+    return acc;
+  }, {});
+
+  // Finally, apply the encoding to the given string.
+  var result = string.split('').map(function (char) {
+    return encoding[char];
+  }).join('');
+
+  return {
+    encoding: encoding,
+    value: (compressed ? compress(result) : result)
+  };
+};
+
+
+/**
+ * Decode a Huffman-encoded string or compressed number sequence.
+ *
+ * @param {Object.<string, string>} encoding - Maps characters to 0-1 sequences.
+ * @param {string|number[]} encodedString
+ * @return {string} Decoded string.
+ */
+huffman.decode = function (encoding, encodedString) {
+  if (Array.isArray(encodedString)) {
+    encodedString = decompress(encodedString);
+  }
+
+  // We can make use of the fact that encoding mapping is always one-to-one
+  // and rely on the power of JS hashes instead of building hand-made FSMs.
+  var letterByCode = Object.keys(encoding).reduce(function (acc, letter) {
+    acc[encoding[letter]] = letter;
+    return acc;
+  }, {});
+
+  var decodedLetters = [];
+
+  var unresolved = encodedString.split('').reduce(function (code, char) {
+    code += char;
+    var letter = letterByCode[code];
+    if (letter) {
+      decodedLetters.push(letter);
+      code = '';
+    }
+    return code;
+  }, '');
+
+  if (unresolved) {
+    throw new Error('Invalid string to decode.');
+  }
+
+  return decodedLetters.join('');
+};
+
+
+module.exports = huffman;

--- a/main.js
+++ b/main.js
@@ -51,7 +51,8 @@ var lib = {
   String: {
     editDistance: require('./algorithms/string/edit_distance'),
     karpRabin: require('./algorithms/string/karp_rabin'),
-    knuthMorrisPratt: require('./algorithms/string/knuth_morris_pratt')
+    knuthMorrisPratt: require('./algorithms/string/knuth_morris_pratt'),
+    huffman: require('./algorithms/string/huffman'),
   },
   DataStructure: {
     BST: require('./data_structures/bst'),

--- a/test/algorithms/string/huffman.js
+++ b/test/algorithms/string/huffman.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2014 Eugene Sharygin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+'use strict';
+
+var huffman = require('../../../algorithms/string/huffman'),
+    assert = require('assert');
+
+
+describe('Huffman', function () {
+  var messages = ['', 'a', 'b', 'hello', 'test', 'awwawwweeeqqq',
+                  'The seething sea ceaseth and thus' +
+                  ' the seething sea sufficeth us.',
+                  'Shep Schwab shopped at Scott\'s Schnapps shop;' +
+                  '\nOne shot of Scott\'s Schnapps stopped Schwab\'s watch.'];
+  for (var randomTestIndex = 0; randomTestIndex < 15; ++randomTestIndex) {
+    var length = Math.floor(Math.random() * 100 + 1);
+    var characters = [];
+    for (var charIndex = 0; charIndex < length; ++charIndex) {
+      var charCode = Math.floor(Math.random() * 10 + 'a'.charCodeAt());
+      characters.push(String.fromCharCode(charCode));
+    }
+    messages.push(characters.join(''));
+  }
+
+  it('should decode previously encoded messages correctly', function () {
+    messages.forEach(function (message) {
+      var encoded = huffman.encode(message);
+      var decoded = huffman.decode(encoded.encoding, encoded.value);
+      assert.equal(message, decoded);
+      var encodedCompressed = huffman.encode(message, true);
+      var decodedCompressed = huffman.decode(encodedCompressed.encoding,
+                                             encodedCompressed.value);
+      assert.equal(message, decodedCompressed);
+    });
+  });
+
+  it('should raise an error if it fails to decode', function () {
+    var badArgs = [[{}, '0'],
+                   [{a: '0', b: '10', c: '11'}, '001']];
+    badArgs.forEach(function (args) {
+      assert.throws(function () {
+        huffman.decode.apply(null, args);
+      });
+    });
+  });
+
+  it('should encode sample strings in the expected manner', function () {
+    assert.deepEqual(huffman.encode(''), {encoding: {}, value: ''});
+    assert.deepEqual(huffman.encode('a'), {encoding: {a: '0'}, value: '0'});
+    assert.deepEqual(huffman.encode('aaaaa'), {encoding: {a: '0'},
+                                               value: '00000'});
+    var result = huffman.encode('aabc');
+    assert.equal(result.encoding.a.length, 1);
+    assert.equal(result.encoding.b.length, 2);
+    assert.equal(result.encoding.c.length, 2);
+    result = huffman.encode('abcdabcdabcdabcd');
+    Object.keys(result.encoding).forEach(function (char) {
+      assert.equal(result.encoding[char].length, 2);
+    });
+    assert.equal(result.value.length, 32);
+  });
+
+  it('should satisfy the entropy condition (H <= cost <= H+1)', function () {
+    messages.forEach(function (message) {
+      var frequencies = message.split('').reduce(function (acc, char) {
+        acc[char] = (acc[char] || 0) + 1;
+        return acc;
+      }, {});
+      Object.keys(frequencies).forEach(function (char) {
+        frequencies[char] /= message.length;
+      });
+      var entropy = Object.keys(frequencies).reduce(function (partial, char) {
+        var freq = frequencies[char];
+        return partial - freq * Math.log(freq);
+      }, 0) / Math.log(2);
+      var encoding = huffman.encode(message).encoding;
+      var cost = Object.keys(encoding).reduce(function (partial, char) {
+        return partial + frequencies[char] * encoding[char].length;
+      }, 0);
+      assert(entropy <= cost);
+      assert(cost <= entropy + 1);
+    });
+  });
+});


### PR DESCRIPTION
Huffman encoding/decoding ([wikipedia](https://en.wikipedia.org/wiki/Huffman_coding)).

The resulting binary code can be returned either as 0-1 string (e.g. `'hello'` -> `1101110010`) or array of int32 numbers (`'hello'` -> `[882, 10]`). The latter case is obviously more memory efficient but less clear to test and play with.

This closes #7.
