### PR TITLE
Explicitly convert graph vertices to string

### DIFF
--- a/data_structures/graph.js
+++ b/data_structures/graph.js
@@ -32,7 +32,7 @@ function Graph(directed) {
 }
 
 Graph.prototype.addVertex = function (v) {
-  this.vertices.push(v);
+  this.vertices.push('' + v);
   this.adjList[v] = {};
 };
 


### PR DESCRIPTION
The (minor) problem with current graph implementation is that `vertices` property contains vertices as they were introduced to `addVertex`, but `neighbors` automatically convert them to string (because internally vertices are used as object keys).

It can lead to some strange results (note the types).

``` javascript
var graph = new Graph();
graph.addEdge(5, 0);
graph.addEdge(0, 2);
graph.addEdge(2, 4);
graph.addEdge(4, 0);
graph.addEdge(1, 5);
graph.addEdge(3, 1);
graph.addEdge(5, 3);

var trail = eulerPath(graph);
// [ 5, '3', '1', 5, '0', '2', '4', 0 ]
```

I understand that this “class” was designed for string vertices in mind, but it is rather common for vertices to be integers as well. String type makes it also easier to implement. The smallest possible fix I can think of is to convert vertices in graph.vertices to strings.
