### PR TITLE
ESLint checks jsdoc too, easily switch rules between off, warning, error...

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,23 @@
+{
+  "env": {
+    "browser": true,
+    "node": true
+  },
+  "globals": {
+    "describe"   : false,
+    "it"         : false,
+    // "before"     : false,
+    // "beforeEach" : false,
+    // "after"      : false,
+    // "afterEach"  : false
+  },
+  "rules": {
+    "eqeqeq": 0,
+    "curly": 0,
+    "quotes": [ 2, "single" ],
+    "valid-jsdoc": 1,
+    "no-use-before-define": 1,
+    "no-underscore-dangle": 1,
+    "no-extend-native": 1
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
-all: jshint coverage
+.PHONY: setup
+
+all: jshint eslint coverage
 
 setup:
 	npm install
 
 jshint: setup
 	jshint algorithms data_structures test util
+
+eslint: setup
+	eslint -f compact algorithms data_structures test util
 
 test: setup
 	mocha -R spec --recursive test

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "istanbul": "^0.2.10",
     "jshint": "~2.4.4",
     "jscs": "1.4.5",
+    "eslint": "0.6.2",
     "mocha": "^1.20.0"
   },
   "repository": {


### PR DESCRIPTION
ESLint does not check for indentation and other coding style, so jscs is still needed.
