### PR TITLE
Reset global state between DFS calls, minor jsdoc fix

### DIFF
--- a/algorithms/graph/depth_first_search.js
+++ b/algorithms/graph/depth_first_search.js
@@ -21,9 +21,13 @@
  */
 'use strict';
 
-var time = 0,
-    visitedNodes = {},
-    finishingTimes = {};
+var newDfsState = function () {
+  return {
+    time: 0,
+    visitedNodes: {},
+    finishingTimes: {}
+  };
+};
 
 /**
  * Depth First Search for all the vertices in the graph
@@ -34,13 +38,27 @@ var time = 0,
  *    vertices are visited
  */
 var dfsAdjacencyListStart = function (graph) {
+  var dfsState = newDfsState();
+
   graph.vertices.forEach(function (v) {
-    if (visitedNodes[v] !== true) {
-      dfsAdjacencyList(graph, v);
+    if (dfsState.visitedNodes[v] !== true) {
+      dfsInternalLoop(graph, v, dfsState);
     }
   });
 
-  return finishingTimes;
+  return dfsState.finishingTimes;
+};
+
+var dfsInternalLoop = function (graph, startNode, dfsState) {
+  dfsState.visitedNodes[startNode] = true;
+
+  graph.neighbors(startNode).forEach(function (v) {
+    if (dfsState.visitedNodes[v] !== true) {
+      dfsInternalLoop(graph, v, dfsState);
+    }
+  });
+
+  dfsState.finishingTimes[startNode] = dfsState.time++;
 };
 
 /**
@@ -52,17 +70,9 @@ var dfsAdjacencyListStart = function (graph) {
  * @return {Object}
  */
 var dfsAdjacencyList = function (graph, startNode) {
-  visitedNodes[startNode] = true;
-
-  graph.neighbors(startNode).forEach(function (v) {
-    if (visitedNodes[v] !== true) {
-      dfsAdjacencyList(graph, v);
-    }
-  });
-
-  finishingTimes[startNode] = time++;
-
-  return finishingTimes;
+  var dfsState = newDfsState();
+  dfsInternalLoop(graph, startNode, dfsState);
+  return dfsState.finishingTimes;
 };
 
 var depthFirstSearch = {

--- a/test/algorithms/graph/depth_first_search.js
+++ b/test/algorithms/graph/depth_first_search.js
@@ -34,7 +34,7 @@ graph.addEdge('three', 'one');
 graph.addEdge('five', 'six');
 
 describe('Depth First Search Algorithm', function () {
-  it('should visit only the nodes reachable from the node {one} (inclusive)',
+  it('should visit only the nodes reachable from the start node (inclusive)',
     function () {
       var finishingTimes = depthFirstSearch.dfsAdjacencyList(graph, 'one');
 
@@ -45,6 +45,11 @@ describe('Depth First Search Algorithm', function () {
       assert.equal(finishingTimes.two, 1);
       assert.equal(finishingTimes.three, 0);
       assert.equal(finishingTimes.four, 2);
+
+      // Finishing times for different calls shouldn't interfere.
+      finishingTimes = depthFirstSearch.dfsAdjacencyList(graph, 'five');
+      assert.equal(finishingTimes.six, 0);
+      assert.equal(finishingTimes.five, 1);
     }
   );
 


### PR DESCRIPTION
DFS algorithm uses global (module-scope) variables `time`, `visitedNodes`, `finishingTimes`, and successive calls share their values. This patch fixes it.
