### PR TITLE
Generalize DFS, make use of it in other algorithms

### DIFF
--- a/algorithms/graph/depth_first_search.js
+++ b/algorithms/graph/depth_first_search.js
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2014 Tayllan Búrigo
+ * Copyright (C) 2014 Eugene Sharygin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"], to
@@ -21,63 +22,87 @@
  */
 'use strict';
 
-var newDfsState = function () {
-  return {
-    time: 0,
-    visitedNodes: {},
-    finishingTimes: {}
-  };
-};
 
 /**
- * Depth First Search for all the vertices in the graph
- * Worst Case Complexity: O(V + E)
- *
- * @param {Object}
- * @return {Object} representing the order in which the
- *    vertices are visited
+ * @typedef {Object} Callbacks
+ * @param {function(vertex: *, neighbor: *): boolean} allowTraversal -
+ *   Determines whether DFS should traverse from the vertex to its neighbor
+ *   (along the edge). By default prohibits visiting the same vertex again.
+ * @param {function(vertex: *, neighbor: *)} beforeTraversal - Called before
+ *   recursive DFS call.
+ * @param {function(vertex: *, neighbor: *)} afterTraversal - Called after
+ *   recursive DFS call.
+ * @param {function(vertex: *)} enterVertex - Called when DFS enters the vertex.
+ * @param {function(vertex: *)} leaveVertex - Called when DFS leaves the vertex.
  */
-var dfsAdjacencyListStart = function (graph) {
-  var dfsState = newDfsState();
 
-  graph.vertices.forEach(function (v) {
-    if (dfsState.visitedNodes[v] !== true) {
-      dfsInternalLoop(graph, v, dfsState);
+
+/**
+ * Fill in missing callbacks.
+ * @param {Callbacks} callbacks
+ * @param {Array} [seenVertices] - Vertices already discovered,
+ *   used by default allowTraversal implementation.
+ * @return {Callbacks} The same object or new one (if null passed).
+ */
+var normalizeCallbacks = function (callbacks, seenVertices) {
+  callbacks = callbacks || {};
+
+  callbacks.allowTraversal = callbacks.allowTraversal || (function () {
+    var seen = (seenVertices || []).reduce(function (seen, vertex) {
+      seen[vertex] = true;
+      return seen;
+    }, {});
+
+    return function (vertex, neighbor) {
+      // It should still be possible to redefine other callbacks,
+      // so we better do all at once here.
+
+      if (!seen[neighbor]) {
+        seen[neighbor] = true;
+        return true;
+      }
+      else {
+        return false;
+      }
+    };
+  }());
+
+  var noop = function () {};
+  callbacks.beforeTraversal = callbacks.beforeTraversal || noop;
+  callbacks.afterTraversal = callbacks.afterTraversal || noop;
+  callbacks.enterVertex = callbacks.enterVertex || noop;
+  callbacks.leaveVertex = callbacks.leaveVertex || noop;
+
+  return callbacks;
+};
+
+
+/**
+ * Run Depth-First Search from a start vertex.
+ * Worst-case complexity: O(V + E).
+ *
+ * @param {Graph} graph
+ * @param {*} startVertex
+ * @param {Callbacks} [callbacks]
+ */
+var depthFirstSearch = function (graph, startVertex, callbacks) {
+  dfsLoop(graph, startVertex, normalizeCallbacks(callbacks, [startVertex]));
+};
+
+
+var dfsLoop = function dfsLoop(graph, vertex, callbacks) {
+  callbacks.enterVertex(vertex);
+
+  graph.neighbors(vertex).forEach(function (neighbor) {
+    if (callbacks.allowTraversal(vertex, neighbor)) {
+      callbacks.beforeTraversal(vertex, neighbor);
+      dfsLoop(graph, neighbor, callbacks);
+      callbacks.afterTraversal(vertex, neighbor);
     }
   });
 
-  return dfsState.finishingTimes;
+  callbacks.leaveVertex(vertex);
 };
 
-var dfsInternalLoop = function (graph, startNode, dfsState) {
-  dfsState.visitedNodes[startNode] = true;
-
-  graph.neighbors(startNode).forEach(function (v) {
-    if (dfsState.visitedNodes[v] !== true) {
-      dfsInternalLoop(graph, v, dfsState);
-    }
-  });
-
-  dfsState.finishingTimes[startNode] = dfsState.time++;
-};
-
-/**
- * Depth First Search for the vertices reachable from 'startNode'
- * Worst Case Complexity: O(V + E)
- *
- * @param {Object}
- * @param {Object}
- * @return {Object}
- */
-var dfsAdjacencyList = function (graph, startNode) {
-  var dfsState = newDfsState();
-  dfsInternalLoop(graph, startNode, dfsState);
-  return dfsState.finishingTimes;
-};
-
-var depthFirstSearch = {
-  dfsAdjacencyList: dfsAdjacencyList,
-  dfsAdjacencyListStart: dfsAdjacencyListStart
-};
 
 module.exports = depthFirstSearch;

--- a/algorithms/graph/euler_path.js
+++ b/algorithms/graph/euler_path.js
@@ -22,7 +22,8 @@
 'use strict';
 
 
-var Graph = require('../../data_structures/graph');
+var Graph = require('../../data_structures/graph'),
+    depthFirstSearch = require('../../algorithms/graph/depth_first_search');
 
 
 /** Examine a graph and compute pair of end vertices of the existing Euler path.
@@ -115,15 +116,17 @@ var eulerPath = function (graph) {
   var seen = new Graph(graph.directed);
   graph.vertices.forEach(seen.addVertex.bind(seen));
 
-  (function dfs(vertex) {
-    graph.neighbors(vertex).forEach(function (neighbor) {
-      if (!seen.edge(vertex, neighbor)) {
-        seen.addEdge(vertex, neighbor);
-        dfs(neighbor);
-        route.push(vertex);
-      }
-    });
-  }(endpoints.start));
+  depthFirstSearch(graph, endpoints.start, {
+    allowTraversal: function (vertex, neighbor) {
+      return !seen.edge(vertex, neighbor);
+    },
+    beforeTraversal: function (vertex, neighbor) {
+      seen.addEdge(vertex, neighbor);
+    },
+    afterTraversal: function (vertex) {
+      route.push(vertex);
+    }
+  });
 
   graph.vertices.forEach(function (vertex) {
     if (seen.neighbors(vertex).length < graph.neighbors(vertex).length) {

--- a/algorithms/graph/topological_sort.js
+++ b/algorithms/graph/topological_sort.js
@@ -21,7 +21,8 @@
  */
 'use strict';
 
-var Stack = require('../../data_structures/stack');
+var Stack = require('../../data_structures/stack'),
+    depthFirstSearch = require('../../algorithms/graph/depth_first_search');
 
 /**
  * Sorts the edges of the DAG topologically
@@ -40,26 +41,21 @@ var Stack = require('../../data_structures/stack');
 var topologicalSort = function (graph) {
   var stack = new Stack();
   var firstHit = {};
-  var secondHit = {};
   var time = 0;
 
-  /**
-  * Depth first search for a directed acyclic graph (DAG)
-  */
-  var dagDFS = function (node) {
-    if (firstHit[node]) return;
-    var neighbors = graph.neighbors(node);
-    firstHit[node] = ++time;
-    for (var i = 0; i < neighbors.length; i++) {
-      dagDFS(neighbors[i]);
-    }
-    secondHit[node] = ++time;
-    stack.push(node);
-  };
-
   graph.vertices.forEach(function (node) {
-    if (!secondHit[node]) {
-      dagDFS(node);
+    if (!firstHit[node]) {
+      depthFirstSearch(graph, node, {
+        allowTraversal: function (node, neighbor) {
+          return !firstHit[neighbor];
+        },
+        enterVertex: function (node) {
+          firstHit[node] = ++time;
+        },
+        leaveVertex: function (node) {
+          stack.push(node);
+        }
+      });
     }
   });
 

--- a/test/algorithms/graph/depth_first_search.js
+++ b/test/algorithms/graph/depth_first_search.js
@@ -36,34 +36,52 @@ graph.addEdge('five', 'six');
 describe('Depth First Search Algorithm', function () {
   it('should visit only the nodes reachable from the start node (inclusive)',
     function () {
-      var finishingTimes = depthFirstSearch.dfsAdjacencyList(graph, 'one');
+      var enter = [], leave = [];
+      var numEdgeTails = 0, numEdgeHeads = 0;
 
-      assert.equal(finishingTimes.five, undefined);
-      assert.equal(finishingTimes.six, undefined);
+      var dfsCallbacks = {
+        enterVertex: [].push.bind(enter),
+        leaveVertex: [].push.bind(leave),
+        beforeTraversal: function () {
+          numEdgeHeads += 1;
+        },
+        afterTraversal: function () {
+          numEdgeTails += 1;
+        }
+      };
 
-      assert.equal(finishingTimes.one, 3);
-      assert.equal(finishingTimes.two, 1);
-      assert.equal(finishingTimes.three, 0);
-      assert.equal(finishingTimes.four, 2);
+      depthFirstSearch(graph, 'one', dfsCallbacks);
+      assert.deepEqual(enter, ['one', 'three', 'four', 'two']);
+      assert.deepEqual(leave, ['three', 'two', 'four', 'one']);
+      assert.equal(numEdgeTails, numEdgeHeads);
+      assert.equal(numEdgeHeads, 3);
 
-      // Finishing times for different calls shouldn't interfere.
-      finishingTimes = depthFirstSearch.dfsAdjacencyList(graph, 'five');
-      assert.equal(finishingTimes.six, 0);
-      assert.equal(finishingTimes.five, 1);
+      enter.splice(0, 4);
+      leave.splice(0, 4);
+      depthFirstSearch(graph, 'five', dfsCallbacks);
+      assert.deepEqual(enter, ['five', 'six']);
+      assert.deepEqual(leave, ['six', 'five']);
+      assert.equal(numEdgeTails, numEdgeHeads);
+      assert.equal(numEdgeHeads, 4);
     }
   );
 
-  it('should visit all the nodes in the graph',
-    function () {
-      var finishingTimes = depthFirstSearch.dfsAdjacencyListStart(graph);
+  it('should allow user-defined allowTraversal rules', function () {
+    var seen = new Graph(graph.directed);
+    graph.vertices.forEach(seen.addVertex.bind(seen));
+    var path = ['one'];
 
-      assert.equal(finishingTimes.one, 3);
-      assert.equal(finishingTimes.two, 1);
-      assert.equal(finishingTimes.three, 0);
-      assert.equal(finishingTimes.four, 2);
-      assert.equal(finishingTimes.five, 5);
-      assert.equal(finishingTimes.six, 4);
-    }
-  );
+    // Edge-centric DFS.
+    depthFirstSearch(graph, path[0], {
+      allowTraversal: function (vertex, neighbor) {
+        return !seen.edge(vertex, neighbor);
+      },
+      beforeTraversal: function (vertex, neighbor) {
+        seen.addEdge(vertex, neighbor);
+        path.push(neighbor);
+      }
+    });
+
+    assert.deepEqual(path, ['one', 'three', 'one', 'four', 'two', 'one']);
+  });
 });
-

--- a/test/algorithms/graph/minimum_spanning_tree.js
+++ b/test/algorithms/graph/minimum_spanning_tree.js
@@ -23,6 +23,7 @@
 
 var kruskal = require('../../../algorithms/graph/kruskal'),
     Graph = require('../../../data_structures/graph'),
+    depthFirstSearch = require('../../../algorithms/graph/depth_first_search'),
     assert = require('assert');
 
 
@@ -33,11 +34,12 @@ var kruskal = require('../../../algorithms/graph/kruskal'),
 var numberOfConnectedComponents = function (graph) {
   assert(!graph.directed);
   var seen = {};
-  var coverComponent = function dfs(start) {
-    if (!seen[start]) {
-      seen[start] = true;
-      graph.neighbors(start).forEach(dfs);
-    }
+  var coverComponent = function (origin) {
+    depthFirstSearch(graph, origin, {
+      enterVertex: function (vertex) {
+        seen[vertex] = true;
+      }
+    });
   };
   return graph.vertices.reduce(function (count, vertex) {
     if (seen[vertex]) {


### PR DESCRIPTION
I appreciate @tayllan's work, but current version of Depth-First Search makes it very hard to reuse this code in other algorithms, because all it does is computing finishing times of nodes and there is nothing user can do about it. Moreover, concerns about finishing times complicate the DFS code itself and make it less clear.

This version supports custom callbacks, which can control any decision DFS makes along the way and can be easily extended later on.

For example, finishing times can be computed as follows:

``` javascript
var finishingTimes = {};
var time = 0;

depthFirstSearch(graph, 'one', {
  leaveVertex: function (vertex) {
    finishingTimes[vertex] = time++;
  }
});
```
