### PR TITLE
Add shortest path algorithm based on Breadth-First Search

### DIFF
--- a/algorithms/graph/bfs_shortest_path.js
+++ b/algorithms/graph/bfs_shortest_path.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var breadthFirstSearch = require('./breadth_first_search');
+
+
+/**
+ * Shortest-path algorithm based on Breadth-First Search.
+ * Works solely on graphs with equal edge weights (but works fast).
+ * Complexity: O(V + E).
+ *
+ * @param {Graph} graph
+ * @param {string} source
+ * @return {{distance: Object.<string, number>,
+ *           previous: Object.<string, string>}}
+ */
+var bfsShortestPath = function (graph, source) {
+  var distance = {}, previous = {};
+  distance[source] = 0;
+
+  breadthFirstSearch(graph, source, {
+    onTraversal: function (vertex, neighbor) {
+      distance[neighbor] = distance[vertex] + 1;
+      previous[neighbor] = vertex;
+    }
+  });
+
+  return {
+    distance: distance,
+    previous: previous
+  };
+};
+
+
+module.exports = bfsShortestPath;

--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ var lib = {
     depthFirstSearch: require('./algorithms/graph/depth_first_search'),
     kruskal: require('./algorithms/graph/kruskal'),
     breadthFirstSearch: require('./algorithms/graph/breadth_first_search'),
+    bfsShortestPath: require('./algorithms/graph/bfs_shortest_path'),
   },
   Math: {
     fibonacci: require('./algorithms/math/fibonacci'),

--- a/test/algorithms/graph/bfs_shortest_path.js
+++ b/test/algorithms/graph/bfs_shortest_path.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var bfsShortestPath = require('../../../algorithms/graph/bfs_shortest_path'),
+    Graph = require('../../../data_structures/graph'),
+    assert = require('assert');
+
+
+describe('BFS Shortest Path Algorithm', function () {
+  it('should return the shortest paths to all nodes from a given origin',
+     function () {
+        var graph = new Graph();
+        graph.addEdge(0, 1);
+        graph.addEdge(1, 2);
+        graph.addEdge(0, 2);
+        graph.addEdge(2, 3);
+        graph.addEdge(3, 6);
+        graph.addEdge(6, 2);
+        graph.addEdge(6, 0);
+        graph.addEdge(0, 4);
+        graph.addEdge(4, 6);
+        graph.addEdge(4, 5);
+        graph.addEdge(5, 0);
+        graph.addEdge('a', 'b');
+
+        var shortestPath = bfsShortestPath(graph, 0);
+
+        assert.deepEqual(shortestPath.distance, {
+          0: 0,
+          1: 1,
+          2: 1,
+          3: 2,
+          4: 1,
+          5: 2,
+          6: 2
+        });
+        assert.deepEqual(shortestPath.previous, {
+          1: 0,
+          2: 0,
+          3: 2,
+          4: 0,
+          5: 4,
+          6: 4
+        });
+      });
+});


### PR DESCRIPTION
Works in O(V+E), which makes it the most efficient shortest-path algorithm for unweighted graphs.
