### PR TITLE
Return previous vertices in Bellman-Ford

### DIFF
--- a/algorithms/graph/bellman_ford.js
+++ b/algorithms/graph/bellman_ford.js
@@ -15,6 +15,7 @@
  */
 var bellmanFord = function (graph, startNode) {
   var minDistance = {};
+  var previousVertex = {};
   var edges = [];
   var adjacencyListSize = 0;
 
@@ -45,6 +46,7 @@ var bellmanFord = function (graph, startNode) {
 
       if (sourceDistance < targetDistance) {
         minDistance[edges[j].target] = sourceDistance;
+        previousVertex[edges[j].target] = edges[j].source;
       }
     }
   }
@@ -63,7 +65,8 @@ var bellmanFord = function (graph, startNode) {
   }
 
   return {
-    distance: minDistance
+    distance: minDistance,
+    previous: previousVertex
   };
 };
 

--- a/test/algorithms/graph/bellman_ford.js
+++ b/test/algorithms/graph/bellman_ford.js
@@ -23,6 +23,8 @@ describe('Bellman-Ford Algorithm', function () {
     assert.equal(shortestPaths.distance.a, 0);
     assert.equal(shortestPaths.distance.d, -2);
     assert.equal(shortestPaths.distance.e, 1);
+    assert.equal(shortestPaths.previous.d, 'e');
+    assert.equal(shortestPaths.previous.e, 'b');
 
     // It'll cause a Negative-Weighted Cycle.
     graph.addEdge('c', 'a', -9);


### PR DESCRIPTION
Other single-source shortest-path algorithms return both `distance` and `previous` objects, and this patch makes Bellman-Ford adhere to the existing interface.
