### PR TITLE
Tail call optimize largest quicksort partition to improve space complexity

### DIFF
--- a/src/algorithms/sorting/quicksort.js
+++ b/src/algorithms/sorting/quicksort.js
@@ -10,10 +10,17 @@ var quicksortInit = function (array, comparatorFn) {
   var comparator = new Comparator(comparatorFn);
 
   return (function quicksort(array, lo, hi) {
-    if (lo < hi) {
+    while (lo < hi) {
       var p = partition(array, comparator, lo, hi);
-      quicksort(array, lo, p - 1);
-      quicksort(array, p + 1, hi);
+      //Chooses only the smallest partition to use recursion on and
+      //tail-optimize the other. This guarantees O(log n) space in worst case.
+      if (p-lo < hi-p) {
+        quicksort(array, lo, p - 1);
+        lo = p+1;
+      } else {
+        quicksort(array, p + 1, hi);
+        hi = p-1;
+      }
     }
 
     return array;

--- a/src/algorithms/sorting/quicksort.js
+++ b/src/algorithms/sorting/quicksort.js
@@ -14,12 +14,12 @@ var quicksortInit = function (array, comparatorFn) {
       var p = partition(array, comparator, lo, hi);
       //Chooses only the smallest partition to use recursion on and
       //tail-optimize the other. This guarantees O(log n) space in worst case.
-      if (p-lo < hi-p) {
+      if (p - lo < hi - p) {
         quicksort(array, lo, p - 1);
-        lo = p+1;
+        lo = p + 1;
       } else {
         quicksort(array, p + 1, hi);
-        hi = p-1;
+        hi = p - 1;
       }
     }
 


### PR DESCRIPTION
In the current implementation, we have this space complexity configuration (because of the call stack size):

* Best case: O(log n)
* Worst case: O(n)
* Average case: O(log n)

This may lead to a StackOverflow in big arrays. In this PR, I propose we TCO the recursion to the largest partition. Doing this, we improve both the best and the worst case space complexities:

* Best case: O(1)
* Worst case: O(log n)
* Average case: O(log n)