### PR TITLE
Error in LinkedList getNode()

### DIFF
--- a/src/data_structures/linked_list.js
+++ b/src/data_structures/linked_list.js
@@ -86,7 +86,7 @@ class LinkedList {
     }
 
     let node = this.head;
-    for (let i = 1; i <= index; i++) {
+    for (let i = 1; i < index; i++) {
       node = node.next;
     }
 


### PR DESCRIPTION
The less than equal to comparison is skipping the required element.